### PR TITLE
Sre 695

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,10 @@
 ---
+ubuntu_version: {{ansible_lsb.id|lower }}-{{ ansible_lsb.codename|lower }}
 # docker-engine is the default package name
 docker_pkg_version: 17.05.0
 docker_pkg_edition: ce
-docker_pkg_name: docker-engine={{ docker_pkg_version }}~{{ docker_pkg_edition }}-0~{{ansible_lsb.id|lower }}-{{ ansible_lsb.codename|lower }}
+docker_pkg_apt_version: {{ docker_pkg_version }}~{{ docker_pkg_edition }}-0~{{ ubuntu_version }}
+docker_pkg_name: docker-engine={{ docker_pkg_apt_version }}
 docker_apt_cache_valid_time: 600
 
 # docker dns path for docker.io package ( changed at ubuntu 14.04 from docker to docker.io )
@@ -15,7 +17,7 @@ apt_key_url: hkp://p80.pool.sks-keyservers.net:80
 # apt repository key signature
 apt_key_sig: 58118E89F3A912897C070ADBF76221572C52609D
 # Name of the apt repository for docker
-apt_repository: deb https://apt.dockerproject.org/repo {{ ansible_lsb.id|lower }}-{{ ansible_lsb.codename|lower }} main
+apt_repository: deb https://apt.dockerproject.org/repo {{ ubuntu_version }} main
 # The following help expose a docker port or to add additional options when
 # running docker daemon.  The default is to not use any special options.
 #docker_opts: >

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,7 +56,8 @@ pip_version_docker_compose: latest
 kernel_update_and_reboot_permitted: no
 
 # Set to 'yes' or 'true' to enable updates (sets 'latest' in apt module)
-update_docker_package: yes
+update_docker_package: no
+update_docker_package_cache: yes
 
 # Change these to 'present' if you're running Ubuntu 12.04-13.10 and are fine with less-than-latest packages
 kernel_pkg_state: latest

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 # docker-engine is the default package name
-docker_pkg_name: docker-engine
+docker_pkg_version: 17.05.0
+docker_pkg_edition: ce
+docker_pkg_name: docker-engine={{ docker_pkg_version }}~{{ docker_pkg_edition }}-0~{{ansible_lsb.id|lower }}-{{ ansible_lsb.codename|lower }}
 docker_apt_cache_valid_time: 600
 
 # docker dns path for docker.io package ( changed at ubuntu 14.04 from docker to docker.io )

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,7 +4,7 @@ ubuntu_version: {{ansible_lsb.id|lower }}-{{ ansible_lsb.codename|lower }}
 docker_pkg_version: 17.05.0
 docker_pkg_edition: ce
 docker_pkg_apt_version: {{ docker_pkg_version }}~{{ docker_pkg_edition }}-0~{{ ubuntu_version }}
-docker_pkg_name: docker-engine={{ docker_pkg_apt_version }}
+docker_pkg_name: docker-engine{{ '' if docker_pkg_version=='latest' else '=' + docker_pkg_apt_version }}
 docker_apt_cache_valid_time: 600
 
 # docker dns path for docker.io package ( changed at ubuntu 14.04 from docker to docker.io )
@@ -55,8 +55,7 @@ pip_version_docker_compose: latest
 # Warning: Use with caution in production environments.
 kernel_update_and_reboot_permitted: no
 
-# Set to 'yes' or 'true' to enable updates (sets 'latest' in apt module)
-update_docker_package: no
+# Set to 'yes' or 'true' to enable cache updates 
 update_docker_package_cache: yes
 
 # Change these to 'present' if you're running Ubuntu 12.04-13.10 and are fine with less-than-latest packages

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -54,7 +54,7 @@ pip_version_docker_compose: latest
 kernel_update_and_reboot_permitted: no
 
 # Set to 'yes' or 'true' to enable updates (sets 'latest' in apt module)
-update_docker_package: no
+update_docker_package: yes
 
 # Change these to 'present' if you're running Ubuntu 12.04-13.10 and are fine with less-than-latest packages
 kernel_pkg_state: latest

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -73,7 +73,7 @@
   apt:
     name: "{{ docker_pkg_name }}"
     state: "{{ 'latest' if update_docker_package else 'present' }}"
-    update_cache: "{{ update_docker_package }}"
+    update_cache: "{{ update_docker_package_cache }}"
     cache_valid_time: "{{ docker_apt_cache_valid_time }}"
 
 - name: Set systemd playbook var

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -72,7 +72,7 @@
 - name: Install (or update) docker package
   apt:
     name: "{{ docker_pkg_name }}"
-    state: "{{ 'latest' if update_docker_package else 'present' }}"
+    state: "{{ 'latest' if docker_pkg_version=='latest' else 'present' }}"
     update_cache: "{{ update_docker_package_cache }}"
     cache_valid_time: "{{ docker_apt_cache_valid_time }}"
 


### PR DESCRIPTION
 Add versioning to docker to update to docker_pkg_version. The only thing that should be changed is the docker_pkg_version.


Update to latest package. Since the version is pinned, it would make sure any old version is updated. For versions older than ce, docker_pkg_name can be changed to be for example  `1.13.1-0~ubuntu-trusty`

 remove update_docker_version variable. If docker_pkg_version is set to latest, then no `=` in docker_pkg_name. checks docker_pkg_name to see if latest for state.

