### PR TITLE
Update to correct var name.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -45,14 +45,14 @@ docker_https_proxy:
 # Flags for whether to install pip packages
 pip_install_pip: true
 pip_install_setuptools: true
-pip_install_docker_py: true
+pip_install_docker: true
 pip_install_docker_compose: true
 install_docker_py_on_1604: false
 
 # Versions for the python packages that are installed
 pip_version_pip: latest
 pip_version_setuptools: latest
-pip_version_docker_py: latest
+pip_version_docker: latest
 pip_version_docker_compose: latest
 
 # If this variable is set to true kernel updates and host restarts are permitted.


### PR DESCRIPTION
Also don't need `install_docker_py_on_1604`, but leaving it for compatibility with vars currently used.