### PR TITLE
auto-detecting python3 interpreter using ansible_python_version

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,6 +3,8 @@
 python_vars_file: >-
   {{ 'python3.yml' if ansible_python_interpreter is defined
                           and 'python3' in ansible_python_interpreter
+                   elif ansible_python_version is defined
+                          and ansible_python_version.startswith('3.')
                        else 'python2.yml' }}
 
 # To use Docker Ansible modules, managed nodes require some Docker Python packages :

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,7 @@
 ---
-# Select python variable file according to the ansible_python_interpreter.
+# Select python variable file according to the ansible_python_version.
 python_vars_file: >-
-  {{ 'python3.yml' if ansible_python_interpreter is defined
-                          and 'python3' in ansible_python_interpreter
+  {{ 'python3.yml' if ansible_python_version.startswith('3.')
                        else 'python2.yml' }}
 
 # To use Docker Ansible modules, managed nodes require some Docker Python packages :


### PR DESCRIPTION
Current 3.9.0 version of the galaxy role selects Python interpreter based on variable `ansible_python_interpreter`, which we would like to avoid in general - that one shall be used only in specific use cases on module level.

Instead we would like to fall to default Python version, as used by Ansible, ie. by using `ansible_python_version` as provided by setup module (see issue [#237](https://github.com/angstwad/docker.ubuntu/issues/237)).

This PR adds new condition - if `ansible_python_interpreter` is defined and set to `python3` - it will be respected - however if that one is not defined at all, it should fall to `ansible_python_version` by default (if the version is `3.x`).