### PR TITLE
Better Python version autodetection

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -74,7 +74,7 @@ pip_install_docker: true
 pip_install_docker_compose: true
 
 # Versions for the python packages that are installed
-pip_version_pip: latest
+pip_version_pip: "20.3.3"
 pip_version_setuptools: latest
 # pip_version_docker is ignored if pip_install_docker_compose is true as docker-compose as a dependency over docker.
 # See var/main.yml for more information.

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,8 +1,7 @@
 ---
-# Select python variable file according to the ansible_python_interpreter.
+# Select python variable file according to the ansible_python_version.
 python_vars_file: >-
-  {{ 'python3.yml' if ansible_python_interpreter is defined
-                          and 'python3' in ansible_python_interpreter
+  {{ 'python3.yml' if ansible_python_version.startswith('3.')
                        else 'python2.yml' }}
 
 # To use Docker Ansible modules, managed nodes require some Docker Python packages :


### PR DESCRIPTION
Current 3.9.0 version of the galaxy role selects Python interpreter based on variable `ansible_python_interpreter`, which we would like to avoid in general - that one shall be used only in specific use cases on module level.

Instead we would like to fall to default Python version, as used by Ansible, ie. by using `ansible_python_version` as provided by setup module (see issue [#237](https://github.com/angstwad/docker.ubuntu/issues/237)).

This PR adds new condition - if `ansible_python_version` is at least "3.x", it will use `python3.yml` configuration  - otherwise it will use `python2.yml`.

Also we are setting `pip` version to **20.3.3**, which is the latest supported by both Python 2 and 3. Once we move fully to Python 3, we can set pip version to `latest` again, as it was before.

This works well in combination of `interpreter_python = auto` and also `auto_legacy`.

Until **python4** is released, this shall work pretty well - but the original Galaxy role is not maintained and we might consider different solution in the future.